### PR TITLE
Limitación de borrado según permiso administrativo

### DIFF
--- a/src/components/biblioteca/bookShelf.js
+++ b/src/components/biblioteca/bookShelf.js
@@ -3,15 +3,15 @@ import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import BookCard from './book'
 import PopUp from '../popup/PopUp'
 import { storage } from '../firebase/firebase'
-import { fetch, noteFirebase, dropBook, openFile } from './bookShelfService'
-
-var books = fetch()
+import { fetch, noteFirebase, dropBook, openFile} from './bookShelfService'
+var admin = false     // TODO get admin from global value
+var college = 'uvg'  // TODO college from global value
+var books = fetch(college)
 var fileDownload = ''
 
 function Bookshelf(props) {
     const [buttonPopUp, setButton] = useState(false)
     const [popUpContent, setPopUpContent] = useState()
-
     const onSubmitFile = (e) => {
         const file = e.target.files[0]
 
@@ -26,13 +26,14 @@ function Bookshelf(props) {
         }
     }
 
+
     const finishUpload = () => {
         let titulo = document.getElementById('titulo').value
         let descripcion = document.getElementById('descripcion').value
 
-        noteFirebase(titulo, descripcion, fileDownload, 'uvg') // TODO college from global value
+        noteFirebase(titulo, descripcion, fileDownload, college) // TODO college from global value
         
-        books = fetch()
+        books = fetch(college)
 
         setTimeout(() => {
             setButton(false)
@@ -41,7 +42,7 @@ function Bookshelf(props) {
 
     const deleteBook = (book) => {
         dropBook(book.code)
-        books = fetch()
+        books = fetch(college)
 
         setTimeout(() => {
             setButton(false)
@@ -56,7 +57,7 @@ function Bookshelf(props) {
                 <h1 className='name' >{book.title}</h1>
                 <p className='details'>{book.content}</p>
                 <button type="button" className="popUp-btn" onClick={() =>{openFile(book.file)}}>Abrir</button>
-                <button type='button' className='delete_btn' onClick={() => deleteBook(book)}>Eliminar</button>
+                <button type='button' className='delete_btn' disabled={!admin} onClick={() => deleteBook(book)}>Eliminar</button>
             </div>
         )
     }

--- a/src/components/biblioteca/bookShelfService.js
+++ b/src/components/biblioteca/bookShelfService.js
@@ -1,7 +1,7 @@
-import { db, storage } from '../firebase/firebase'
+import { auth, db, storage } from '../firebase/firebase'
 import { ref, getDownloadURL } from 'firebase/storage'
 
-function fetch() {
+function fetch(u) {
     const libros = []
 
     db.collection('archivos')
@@ -18,7 +18,7 @@ function fetch() {
                     id, title, content, file, code,
                 }
                 // TODO check college with global value
-                if (college === /*'usac'*/ 'uvg') {
+                if (college === u) {
                     libros.push(book)
                 }
             })
@@ -65,4 +65,4 @@ function openFile(item){
     })
 }
 
-export { fetch, noteFirebase, dropBook, openFile }
+export { fetch, noteFirebase, dropBook, openFile}


### PR DESCRIPTION
Se creó una condicional que no permite borrar archivos si es que no tiene estatus de administrador. Esto se logra con la desactivación del botón de borrado si el negativo de la variable que indica si es un usuario administrativo es verdadero. De igual manera, usando la nueva arquitectura separada, se hicieron actualizaciones menores al método de fetch y sus llamadas para que la implmentación del provider sea más fácil.